### PR TITLE
refactor: finalize Publication API and secure download endpoint

### DIFF
--- a/src/main/java/id/perumdamts/mail/controller/core/PublicationController.java
+++ b/src/main/java/id/perumdamts/mail/controller/core/PublicationController.java
@@ -1,9 +1,8 @@
 package id.perumdamts.mail.controller.core;
 
-import id.perumdamts.mail.dto.common.PagedResponse;
 import id.perumdamts.mail.dto.core.publication.CreatePublicationRequest;
-import id.perumdamts.mail.dto.core.publication.PublicationDto;
 import id.perumdamts.mail.dto.core.publication.PublicationParams;
+import id.perumdamts.mail.dto.core.publication.PublicationResponse;
 import id.perumdamts.mail.dto.core.publication.UpdatePublicationRequest;
 import id.perumdamts.mail.entity.core.Publication;
 import id.perumdamts.mail.security.MailPrincipal;
@@ -14,12 +13,14 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.core.io.Resource;
+import org.springframework.data.web.PagedModel;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
@@ -32,22 +33,20 @@ public class PublicationController {
     private final SqidsEncoder encoder;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<PublicationDto> create(
+    public ResponseEntity<PublicationResponse> create(
             @AuthenticationPrincipal MailPrincipal principal,
-            @Valid @RequestPart("data") CreatePublicationRequest request,
-            @RequestPart(value = "file", required = false) MultipartFile file) {
+            @Valid @ModelAttribute CreatePublicationRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(commandService.create(request, file, principal));
+                .body(commandService.create(request, principal));
     }
 
     @PutMapping(value = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public PublicationDto update(
+    public PublicationResponse update(
             @AuthenticationPrincipal MailPrincipal principal,
             @PathVariable String id,
-            @Valid @RequestPart("data") UpdatePublicationRequest request,
-            @RequestPart(value = "file", required = false) MultipartFile file) {
+            @Valid @ModelAttribute UpdatePublicationRequest request) {
         long rawId = encoder.decode(Publication.class, id);
-        return commandService.update(rawId, request, file, principal);
+        return commandService.update(rawId, request, principal);
     }
 
     @DeleteMapping("/{id}")
@@ -60,14 +59,24 @@ public class PublicationController {
     }
 
     @GetMapping
-    public PagedResponse<PublicationDto> list(@ParameterObject PublicationParams params) {
-        log.debug("kentoes sort {}", params.toSortField());
-        return queryService.list(params);
+    public PagedModel<PublicationResponse> findAll(@ParameterObject PublicationParams params) {
+        return new PagedModel<>(queryService.findAll(params));
     }
 
     @GetMapping("/{id}")
-    public PublicationDto findById(@PathVariable String id) {
+    public PublicationResponse findById(@PathVariable String id) {
         long rawId = encoder.decode(Publication.class, id);
         return queryService.findById(rawId);
+    }
+
+    @GetMapping("/{id}/download")
+    public ResponseEntity<Resource> download(@PathVariable String id) {
+        long rawId = encoder.decode(Publication.class, id);
+        var result = queryService.download(rawId);
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=\"" + result.filename() + "\"")
+                .body(result.resource());
     }
 }

--- a/src/main/java/id/perumdamts/mail/dto/core/publication/CreatePublicationRequest.java
+++ b/src/main/java/id/perumdamts/mail/dto/core/publication/CreatePublicationRequest.java
@@ -1,11 +1,16 @@
 package id.perumdamts.mail.dto.core.publication;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
 
-public record CreatePublicationRequest(
-        @NotBlank String title,
-        String description,
-        @NotBlank String documentTypeId,
-        boolean publish
-) {
+@Data
+public class CreatePublicationRequest {
+    @NotBlank
+    private String title;
+    private String description;
+    @NotBlank
+    private String documentTypeId;
+    private boolean publish;
+    private MultipartFile file;
 }

--- a/src/main/java/id/perumdamts/mail/dto/core/publication/PublicationDownloadResult.java
+++ b/src/main/java/id/perumdamts/mail/dto/core/publication/PublicationDownloadResult.java
@@ -1,0 +1,5 @@
+package id.perumdamts.mail.dto.core.publication;
+
+import org.springframework.core.io.Resource;
+
+public record PublicationDownloadResult(String filename, Resource resource) {}

--- a/src/main/java/id/perumdamts/mail/dto/core/publication/PublicationMapper.java
+++ b/src/main/java/id/perumdamts/mail/dto/core/publication/PublicationMapper.java
@@ -20,8 +20,7 @@ public abstract class PublicationMapper extends SqidMapper<Publication> {
     @Mapping(target = "id", expression = "java(sqid(entity))")
     @Mapping(source = "documentType", target = "documentType")
     @Mapping(source = "status", target = "status")
-    @Mapping(target = "totalCount", ignore = true)
-    public abstract PublicationDto toDto(Publication entity);
+    public abstract PublicationResponse toDto(Publication entity);
 
     @Mapping(target = "id", expression = "java(entity.getId() != null ? encoder.encode(DocumentType.class, entity.getId()) : null)")
     public abstract DocumentTypeLookup toDto(DocumentType entity);

--- a/src/main/java/id/perumdamts/mail/dto/core/publication/PublicationResponse.java
+++ b/src/main/java/id/perumdamts/mail/dto/core/publication/PublicationResponse.java
@@ -7,7 +7,7 @@ import lombok.Value;
 import java.time.LocalDateTime;
 
 @Value
-public class PublicationDto implements HasSqid {
+public class PublicationResponse implements HasSqid {
     String id;
     String title;
     String description;
@@ -15,12 +15,10 @@ public class PublicationDto implements HasSqid {
     String status;
     LocalDateTime publishedDate;
     String fileName;
-    String filePath;
     Integer fileSize;
     String createdByName;
     String createdByTitle;
     Integer createdByUserId;
     LocalDateTime createdAt;
     LocalDateTime updatedAt;
-    Integer totalCount;
 }

--- a/src/main/java/id/perumdamts/mail/dto/core/publication/UpdatePublicationRequest.java
+++ b/src/main/java/id/perumdamts/mail/dto/core/publication/UpdatePublicationRequest.java
@@ -1,11 +1,16 @@
 package id.perumdamts.mail.dto.core.publication;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
 
-public record UpdatePublicationRequest(
-        @NotBlank String title,
-        String description,
-        @NotBlank String documentTypeId,
-        boolean publish
-) {
+@Data
+public class UpdatePublicationRequest {
+    @NotBlank
+    private String title;
+    private String description;
+    @NotBlank
+    private String documentTypeId;
+    private boolean publish;
+    private MultipartFile file;
 }

--- a/src/main/java/id/perumdamts/mail/repository/core/jooq/PublicationQueryRepository.java
+++ b/src/main/java/id/perumdamts/mail/repository/core/jooq/PublicationQueryRepository.java
@@ -1,7 +1,7 @@
 package id.perumdamts.mail.repository.core.jooq;
 
-import id.perumdamts.mail.dto.core.publication.PublicationDto;
 import id.perumdamts.mail.dto.core.publication.PublicationParams;
+import id.perumdamts.mail.dto.core.publication.PublicationResponse;
 import id.perumdamts.mail.dto.master.documentType.DocumentTypeLookup;
 import id.perumdamts.mail.entity.core.Publication;
 import id.perumdamts.mail.entity.master.DocumentType;
@@ -11,6 +11,9 @@ import org.jooq.Condition;
 import org.jooq.DSLContext;
 import org.jooq.Record;
 import org.jooq.SortField;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -31,7 +34,7 @@ public class PublicationQueryRepository {
         this.encoder = encoder;
     }
 
-    public List<PublicationDto> findAll(PublicationParams params) {
+    public Page<PublicationResponse> findAll(PublicationParams params) {
         Condition condition = field("p.status").ne(inline("DELETED"));
 
         if (params.getStatus() != null) {
@@ -53,8 +56,7 @@ public class PublicationQueryRepository {
 
         SortField<?> sort = params.toSortField();
 
-
-        return dsl.select(
+        var records = dsl.select(
                         field("p.id"),
                         field("p.judul"),
                         field("p.desk"),
@@ -63,7 +65,6 @@ public class PublicationQueryRepository {
                         field("p.status"),
                         field("p.published_date"),
                         field("p.file_name"),
-                        field("p.file_path"),
                         field("p.file_size"),
                         field("p.created_by_name"),
                         field("p.created_by_title"),
@@ -78,13 +79,17 @@ public class PublicationQueryRepository {
                 .orderBy(sort)
                 .limit(params.getSize())
                 .offset(params.offset())
-                .fetch(this::toDto)
-                .stream()
+                .fetch();
+
+        long total = records.isEmpty() ? 0 : records.getFirst().get(field("total_count"), Long.class);
+        List<PublicationResponse> content = records.map(this::toDto).stream()
                 .filter(java.util.Objects::nonNull)
                 .toList();
+
+        return new PageImpl<>(content, PageRequest.of(params.getPage(), params.getSize()), total);
     }
 
-    public Optional<PublicationDto> findById(Long id) {
+    public Optional<PublicationResponse> findById(Long id) {
         var result = dsl.select(
                         field("p.id"),
                         field("p.judul"),
@@ -94,7 +99,6 @@ public class PublicationQueryRepository {
                         field("p.status"),
                         field("p.published_date"),
                         field("p.file_name"),
-                        field("p.file_path"),
                         field("p.file_size"),
                         field("p.created_by_name"),
                         field("p.created_by_title"),
@@ -106,21 +110,12 @@ public class PublicationQueryRepository {
                 .leftJoin(table("jenis_dokumen").as("jd")).on(field("jd.id").eq(field("p.type")))
                 .where(field("p.id").eq(id))
                 .and(field("p.status").ne(inline("DELETED")))
-                .fetchOne(this::toDtoNoCount);
+                .fetchOne(this::toDto);
 
         return Optional.ofNullable(result);
     }
 
-    private PublicationDto toDto(Record r) {
-        Integer totalCount = r.get(field("total_count"), Integer.class);
-        return mapToPublicationDto(r, totalCount != null ? totalCount : 0);
-    }
-
-    private PublicationDto toDtoNoCount(Record r) {
-        return mapToPublicationDto(r, null);
-    }
-
-    private PublicationDto mapToPublicationDto(Record r, Integer totalCount) {
+    private PublicationResponse toDto(Record r) {
         Long id = r.get(field("p.id"), Long.class);
         if (id == null) {
             log.warn("Null id found in publication record, skipping");
@@ -131,7 +126,7 @@ public class PublicationQueryRepository {
         String docTypeName = r.get(field("jd.jenis_dokumen"), String.class);
         DocumentTypeLookup docType = docTypeId != null ? new DocumentTypeLookup(encoder.encode(DocumentType.class, docTypeId), docTypeName) : null;
 
-        return new PublicationDto(
+        return new PublicationResponse(
                 encoder.encode(Publication.class, id),
                 r.get(field("p.judul"), String.class),
                 r.get(field("p.desk"), String.class),
@@ -139,14 +134,12 @@ public class PublicationQueryRepository {
                 r.get(field("p.status"), String.class),
                 r.get(field("p.published_date"), LocalDateTime.class),
                 r.get(field("p.file_name"), String.class),
-                r.get(field("p.file_path"), String.class),
                 r.get(field("p.file_size"), Integer.class),
                 r.get(field("p.created_by_name"), String.class),
                 r.get(field("p.created_by_title"), String.class),
                 r.get(field("p.created_by_user_id"), Integer.class),
                 r.get(field("p.created_at"), LocalDateTime.class),
-                r.get(field("p.updated_at"), LocalDateTime.class),
-                totalCount
+                r.get(field("p.updated_at"), LocalDateTime.class)
         );
     }
 }

--- a/src/main/java/id/perumdamts/mail/service/core/attachment/AttachmentService.java
+++ b/src/main/java/id/perumdamts/mail/service/core/attachment/AttachmentService.java
@@ -1,5 +1,20 @@
 package id.perumdamts.mail.service.core.attachment;
 
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
 import id.perumdamts.mail.config.StorageProperties;
 import id.perumdamts.mail.dto.core.attachment.AttachmentMapper;
 import id.perumdamts.mail.dto.core.attachment.AttachmentResponse;
@@ -10,38 +25,19 @@ import id.perumdamts.mail.repository.core.jpa.AttachmentDownloadHistoryRepositor
 import id.perumdamts.mail.repository.core.jpa.AttachmentRepository;
 import id.perumdamts.mail.security.MailPrincipal;
 import jakarta.persistence.EntityNotFoundException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.UrlResource;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
-import java.util.List;
-import java.util.UUID;
 
 @Service
 @Transactional(readOnly = true)
 public class AttachmentService {
-
-    private static final Logger log = LoggerFactory.getLogger(AttachmentService.class);
-
     private final AttachmentRepository repository;
     private final AttachmentDownloadHistoryRepository historyRepository;
     private final AttachmentMapper mapper;
     private final Path storagePath;
 
     public AttachmentService(AttachmentRepository repository,
-                             AttachmentDownloadHistoryRepository historyRepository,
-                             AttachmentMapper mapper,
-                             StorageProperties storageProperties) {
+            AttachmentDownloadHistoryRepository historyRepository,
+            AttachmentMapper mapper,
+            StorageProperties storageProperties) {
         this.repository = repository;
         this.historyRepository = historyRepository;
         this.mapper = mapper;
@@ -65,7 +61,7 @@ public class AttachmentService {
 
     @Transactional
     public AttachmentResponse upload(MultipartFile file, AttachmentRefType refType, Long refId,
-                                     String docNotes, MailPrincipal principal) {
+            String docNotes, MailPrincipal principal) {
         String originalFilename = file.getOriginalFilename();
         String fileExt = extractExtension(originalFilename);
         String systemFilename = UUID.randomUUID() + (fileExt.isEmpty() ? "" : "." + fileExt);
@@ -102,8 +98,7 @@ public class AttachmentService {
                 attachment.getId(),
                 parseUserId(principal.userId()),
                 principal.name(),
-                null
-        ));
+                null));
 
         Path filePath = storagePath.resolve(attachment.getSystemFilename()).normalize();
         if (!filePath.startsWith(storagePath)) {
@@ -135,7 +130,8 @@ public class AttachmentService {
     }
 
     private String extractExtension(String filename) {
-        if (filename == null) return "";
+        if (filename == null)
+            return "";
         int dot = filename.lastIndexOf('.');
         return dot >= 0 ? filename.substring(dot + 1).toLowerCase() : "";
     }
@@ -148,5 +144,6 @@ public class AttachmentService {
         }
     }
 
-    public record DownloadResult(Resource resource, String filename, Integer fileSize) {}
+    public record DownloadResult(Resource resource, String filename, Integer fileSize) {
+    }
 }

--- a/src/main/java/id/perumdamts/mail/service/core/publication/PublicationCommandService.java
+++ b/src/main/java/id/perumdamts/mail/service/core/publication/PublicationCommandService.java
@@ -2,7 +2,7 @@ package id.perumdamts.mail.service.core.publication;
 
 import id.perumdamts.mail.config.StorageProperties;
 import id.perumdamts.mail.dto.core.publication.CreatePublicationRequest;
-import id.perumdamts.mail.dto.core.publication.PublicationDto;
+import id.perumdamts.mail.dto.core.publication.PublicationResponse;
 import id.perumdamts.mail.dto.core.publication.PublicationMapper;
 import id.perumdamts.mail.dto.core.publication.UpdatePublicationRequest;
 import id.perumdamts.mail.entity.core.Publication;
@@ -63,29 +63,29 @@ public class PublicationCommandService {
 
     @Transactional
     @PreAuthorize("hasRole('ADMIN')")
-    public PublicationDto create(CreatePublicationRequest request, MultipartFile file,
-                                  MailPrincipal principal) {
+    public PublicationResponse create(CreatePublicationRequest request, MailPrincipal principal) {
         var pub = new Publication();
-        pub.setTitle(request.title());
-        pub.setDescription(request.description());
-        long documentTypeId = encoder.decode(DocumentType.class, request.documentTypeId());
+        pub.setTitle(request.getTitle());
+        pub.setDescription(request.getDescription());
+        long documentTypeId = encoder.decode(DocumentType.class, request.getDocumentTypeId());
         pub.setDocumentType(documentTypeRepository.getReferenceById(documentTypeId));
         pub.setCreatedByUserId(Integer.parseInt(principal.userId()));
         pub.setCreatedByName(principal.name());
         pub.setCreatedAt(LocalDateTime.now());
 
+        var file = request.getFile();
         if (file != null && !file.isEmpty()) {
             allowedFileTypeService.validate("PUBLICATION", file);
             storeFile(pub, file);
         }
 
-        if (request.publish()) {
+        if (request.isPublish()) {
             pub.publish();
         }
 
         pub = publicationRepository.save(pub);
 
-        if (request.publish()) {
+        if (request.isPublish()) {
             eventPublisher.publishEvent(new PublicationPublishedEvent(pub.getId(), principal.name()));
         }
 
@@ -94,16 +94,16 @@ public class PublicationCommandService {
 
     @Transactional
     @PreAuthorize("hasRole('ADMIN')")
-    public PublicationDto update(Long id, UpdatePublicationRequest request, MultipartFile file,
-                                  MailPrincipal principal) {
+    public PublicationResponse update(Long id, UpdatePublicationRequest request, MailPrincipal principal) {
         var pub = getOrThrow(id);
 
-        pub.setTitle(request.title());
-        pub.setDescription(request.description());
-        long documentTypeId = encoder.decode(DocumentType.class, request.documentTypeId());
+        pub.setTitle(request.getTitle());
+        pub.setDescription(request.getDescription());
+        long documentTypeId = encoder.decode(DocumentType.class, request.getDocumentTypeId());
         pub.setDocumentType(documentTypeRepository.getReferenceById(documentTypeId));
         pub.setUpdatedAt(LocalDateTime.now());
 
+        var file = request.getFile();
         if (file != null && !file.isEmpty()) {
             allowedFileTypeService.validate("PUBLICATION", file);
             deleteOldFile(pub);
@@ -111,13 +111,13 @@ public class PublicationCommandService {
         }
 
         boolean wasPublished = pub.isPublished();
-        if (request.publish() && pub.isDraft()) {
+        if (request.isPublish() && pub.isDraft()) {
             pub.publish();
         }
 
         pub = publicationRepository.save(pub);
 
-        if (request.publish() && !wasPublished) {
+        if (request.isPublish() && !wasPublished) {
             eventPublisher.publishEvent(new PublicationPublishedEvent(pub.getId(), principal.name()));
         }
 

--- a/src/main/java/id/perumdamts/mail/service/core/publication/PublicationQueryService.java
+++ b/src/main/java/id/perumdamts/mail/service/core/publication/PublicationQueryService.java
@@ -1,35 +1,70 @@
 package id.perumdamts.mail.service.core.publication;
 
-import id.perumdamts.mail.dto.common.PagedResponse;
-import id.perumdamts.mail.dto.core.publication.PublicationDto;
+import id.perumdamts.mail.config.StorageProperties;
+import id.perumdamts.mail.dto.core.publication.PublicationDownloadResult;
 import id.perumdamts.mail.dto.core.publication.PublicationParams;
+import id.perumdamts.mail.dto.core.publication.PublicationResponse;
+import id.perumdamts.mail.repository.core.jpa.PublicationRepository;
 import id.perumdamts.mail.repository.core.jooq.PublicationQueryRepository;
 import jakarta.persistence.EntityNotFoundException;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.net.MalformedURLException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 @Service
 @Transactional(readOnly = true)
-@RequiredArgsConstructor
 @Slf4j
 public class PublicationQueryService {
 
     private final PublicationQueryRepository queryRepository;
+    private final PublicationRepository publicationRepository;
+    private final Path storagePath;
 
-    public PagedResponse<PublicationDto> list(PublicationParams params) {
-        List<PublicationDto> items = queryRepository.findAll(params);
-        long total = items.isEmpty() ? 0 : (items.getFirst().getTotalCount() != null ? items.getFirst().getTotalCount() : 0L);
-        PagedResponse<PublicationDto> result = PagedResponse.of(items, params, total);
-        log.debug("result {}, total {}, page {}, size {}", result.content().size(), result.totalElements(), result.page(), result.size());
-        return result;
+    public PublicationQueryService(PublicationQueryRepository queryRepository,
+                                   PublicationRepository publicationRepository,
+                                   StorageProperties storageProperties) {
+        this.queryRepository = queryRepository;
+        this.publicationRepository = publicationRepository;
+        this.storagePath = Paths.get(storageProperties.basePath()).toAbsolutePath().normalize();
     }
 
-    public PublicationDto findById(Long id) {
+    public Page<PublicationResponse> findAll(PublicationParams params) {
+        return queryRepository.findAll(params);
+    }
+
+    public PublicationResponse findById(Long id) {
         return queryRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Publication not found: " + id));
+    }
+
+    public PublicationDownloadResult download(Long id) {
+        var entity = publicationRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Publication not found: " + id));
+
+        if (entity.getFilePath() == null || entity.getFilePath().isBlank()) {
+            throw new IllegalStateException("Publication has no file: " + id);
+        }
+
+        Path filePath = storagePath.resolve(entity.getFilePath()).normalize();
+        if (!filePath.startsWith(storagePath)) {
+            throw new IllegalStateException("Invalid stored file path");
+        }
+
+        try {
+            Resource resource = new UrlResource(filePath.toUri());
+            if (!resource.exists()) {
+                throw new IllegalStateException("File not found on disk: " + entity.getFilePath());
+            }
+            return new PublicationDownloadResult(entity.getFileName(), resource);
+        } catch (MalformedURLException e) {
+            throw new IllegalStateException("Malformed file path: " + filePath, e);
+        }
     }
 }

--- a/src/test/java/id/perumdamts/mail/repository/core/jooq/PublicationQueryRepositoryTest.java
+++ b/src/test/java/id/perumdamts/mail/repository/core/jooq/PublicationQueryRepositoryTest.java
@@ -1,8 +1,8 @@
 package id.perumdamts.mail.repository.core.jooq;
 
 import id.perumdamts.mail.config.SqidsProperties;
-import id.perumdamts.mail.dto.core.publication.PublicationDto;
 import id.perumdamts.mail.dto.core.publication.PublicationParams;
+import id.perumdamts.mail.dto.core.publication.PublicationResponse;
 import id.perumdamts.mail.enums.PublicationStatus;
 import id.perumdamts.mail.util.SqidsEncoder;
 import lombok.extern.slf4j.Slf4j;
@@ -13,10 +13,10 @@ import org.jooq.tools.jdbc.MockConnection;
 import org.jooq.tools.jdbc.MockDataProvider;
 import org.jooq.tools.jdbc.MockResult;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -35,14 +35,13 @@ class PublicationQueryRepositoryTest {
     private static final Field<String> P_STATUS = field("p.status", String.class);
     private static final Field<LocalDateTime> P_PUBLISHED_DATE = field("p.published_date", LocalDateTime.class);
     private static final Field<String> P_FILE_NAME = field("p.file_name", String.class);
-    private static final Field<String> P_FILE_PATH = field("p.file_path", String.class);
     private static final Field<Integer> P_FILE_SIZE = field("p.file_size", Integer.class);
     private static final Field<String> P_CREATED_BY_NAME = field("p.created_by_name", String.class);
     private static final Field<String> P_CREATED_BY_TITLE = field("p.created_by_title", String.class);
     private static final Field<Integer> P_CREATED_BY_USER_ID = field("p.created_by_user_id", Integer.class);
     private static final Field<LocalDateTime> P_CREATED_AT = field("p.created_at", LocalDateTime.class);
     private static final Field<LocalDateTime> P_UPDATED_AT = field("p.updated_at", LocalDateTime.class);
-    private static final Field<Integer> TOTAL_COUNT = field("total_count", Integer.class);
+    private static final Field<Long> TOTAL_COUNT = field("total_count", Long.class);
 
     @Test
     void findAll_shouldExcludeDeletedAndMapDto() {
@@ -54,17 +53,17 @@ class PublicationQueryRepositoryTest {
         PublicationQueryRepository repository = repositoryWithProvider(ctx -> {
             capturedSql.set(ctx.sql());
             return new MockResult[]{
-                    new MockResult(2, publicationRows(true, 2))
+                    new MockResult(2, publicationRows(true, 2L))
             };
         });
 
-        List<PublicationDto> items = repository.findAll(params);
+        Page<PublicationResponse> page = repository.findAll(params);
 
-        assertThat(items).hasSize(2);
-        assertThat(items.getFirst().getId()).startsWith("pbl_");
-        assertThat(items.getFirst().getDocumentType()).isNotNull();
-        assertThat(items.getFirst().getTotalCount()).isEqualTo(2);
-        assertThat(items.get(1).getDocumentType()).isNull();
+        assertThat(page.getContent()).hasSize(2);
+        assertThat(page.getTotalElements()).isEqualTo(2);
+        assertThat(page.getContent().getFirst().getId()).startsWith("pbl_");
+        assertThat(page.getContent().getFirst().getDocumentType()).isNotNull();
+        assertThat(page.getContent().get(1).getDocumentType()).isNull();
         assertThat(normalize(capturedSql.get())).contains("p.status <> 'deleted'");
         log.info("SQL: {}", capturedSql.get());
     }
@@ -86,7 +85,7 @@ class PublicationQueryRepositoryTest {
         PublicationQueryRepository repository = repositoryWithProvider(ctx -> {
             capturedSql.set(ctx.sql());
             return new MockResult[]{
-                    new MockResult(1, publicationRows(true, 1))
+                    new MockResult(1, publicationRows(true, 1L))
             };
         });
 
@@ -109,11 +108,10 @@ class PublicationQueryRepositoryTest {
                 new MockResult(1, publicationRows(false, null))
         });
 
-        Optional<PublicationDto> result = repository.findById(10L);
+        Optional<PublicationResponse> result = repository.findById(10L);
 
         assertThat(result).isPresent();
         assertThat(result.get().getId()).startsWith("pbl_");
-        assertThat(result.get().getTotalCount()).isNull();
         assertThat(result.get().getDocumentType().getId()).isNotNull();
     }
 
@@ -123,7 +121,7 @@ class PublicationQueryRepositoryTest {
                 new MockResult(0, DSL.using(SQLDialect.H2).newResult(P_ID))
         });
 
-        Optional<PublicationDto> result = repository.findById(99L);
+        Optional<PublicationResponse> result = repository.findById(99L);
 
         assertThat(result).isEmpty();
     }
@@ -134,18 +132,18 @@ class PublicationQueryRepositoryTest {
         return new PublicationQueryRepository(dsl, encoder);
     }
 
-    private static Result<Record> publicationRows(boolean includeCount, Integer countValue) {
+    private static Result<Record> publicationRows(boolean includeCount, Long countValue) {
         DSLContext dsl = DSL.using(SQLDialect.H2);
         Field<?>[] fields = includeCount
                 ? new Field<?>[]{
                 P_ID, P_JUDUL, P_DESK, P_TYPE, JD_JENIS_DOKUMEN, P_STATUS,
-                P_PUBLISHED_DATE, P_FILE_NAME, P_FILE_PATH, P_FILE_SIZE,
+                P_PUBLISHED_DATE, P_FILE_NAME, P_FILE_SIZE,
                 P_CREATED_BY_NAME, P_CREATED_BY_TITLE, P_CREATED_BY_USER_ID,
                 P_CREATED_AT, P_UPDATED_AT, TOTAL_COUNT
         }
                 : new Field<?>[]{
                 P_ID, P_JUDUL, P_DESK, P_TYPE, JD_JENIS_DOKUMEN, P_STATUS,
-                P_PUBLISHED_DATE, P_FILE_NAME, P_FILE_PATH, P_FILE_SIZE,
+                P_PUBLISHED_DATE, P_FILE_NAME, P_FILE_SIZE,
                 P_CREATED_BY_NAME, P_CREATED_BY_TITLE, P_CREATED_BY_USER_ID,
                 P_CREATED_AT, P_UPDATED_AT
         };
@@ -161,7 +159,6 @@ class PublicationQueryRepositoryTest {
         first.set(P_STATUS, "PUBLISHED");
         first.set(P_PUBLISHED_DATE, now);
         first.set(P_FILE_NAME, "policy.pdf");
-        first.set(P_FILE_PATH, "/files/policy.pdf");
         first.set(P_FILE_SIZE, 128);
         first.set(P_CREATED_BY_NAME, "Admin");
         first.set(P_CREATED_BY_TITLE, "Manager");
@@ -183,7 +180,6 @@ class PublicationQueryRepositoryTest {
             second.set(P_STATUS, "PUBLISHED");
             second.set(P_PUBLISHED_DATE, now);
             second.set(P_FILE_NAME, "no-type.pdf");
-            second.set(P_FILE_PATH, "/files/no-type.pdf");
             second.set(P_FILE_SIZE, 64);
             second.set(P_CREATED_BY_NAME, "System");
             second.set(P_CREATED_BY_TITLE, "Automated");

--- a/src/test/java/id/perumdamts/mail/service/core/publication/PublicationQueryServiceTest.java
+++ b/src/test/java/id/perumdamts/mail/service/core/publication/PublicationQueryServiceTest.java
@@ -1,16 +1,20 @@
 package id.perumdamts.mail.service.core.publication;
 
-import id.perumdamts.mail.dto.common.PagedResponse;
-import id.perumdamts.mail.dto.core.publication.PublicationDto;
+import id.perumdamts.mail.config.StorageProperties;
 import id.perumdamts.mail.dto.core.publication.PublicationParams;
+import id.perumdamts.mail.dto.core.publication.PublicationResponse;
+import id.perumdamts.mail.repository.core.jpa.PublicationRepository;
 import id.perumdamts.mail.repository.core.jooq.PublicationQueryRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 import java.util.Optional;
@@ -30,56 +34,61 @@ class PublicationQueryServiceTest {
     @Mock
     private PublicationQueryRepository queryRepository;
 
-    @InjectMocks
+    @Mock
+    private PublicationRepository publicationRepository;
+
     private PublicationQueryService service;
 
-    @Test
-    void list_shouldBuildPagedResponseUsingFirstItemTotalCount() {
-        PublicationParams params = new PublicationParams();
-        PublicationDto first = publicationDto("pub-1", 12);
-        PublicationDto second = publicationDto("pub-2", 12);
-        List<PublicationDto> items = List.of(first, second);
-
-        when(queryRepository.findAll(any(PublicationParams.class))).thenReturn(items);
-
-        PagedResponse<PublicationDto> result = service.list(params);
-
-        assertThat(result.content()).containsExactly(first, second);
-        assertThat(result.totalElements()).isEqualTo(12);
-        assertThat(result.page()).isEqualTo(params.getPage());
-        assertThat(result.size()).isEqualTo(params.getSize());
-        verify(queryRepository).findAll(eq(params));
-        verifyNoMoreInteractions(queryRepository);
-
-        log.info("paged, {}",result);
+    @BeforeEach
+    void setUp() {
+        service = new PublicationQueryService(queryRepository, publicationRepository,
+                new StorageProperties("/tmp/test-storage"));
     }
 
     @Test
-    void list_shouldReturnZeroTotalWhenRepositoryReturnsEmptyList() {
+    void findAll_shouldDelegateToRepository() {
         PublicationParams params = new PublicationParams();
+        PublicationResponse first = publicationResponse("pub-1");
+        PublicationResponse second = publicationResponse("pub-2");
+        Page<PublicationResponse> page = new PageImpl<>(List.of(first, second), PageRequest.of(0, 10), 12);
 
-        when(queryRepository.findAll(any(PublicationParams.class))).thenReturn(List.of());
+        when(queryRepository.findAll(any(PublicationParams.class))).thenReturn(page);
 
-        PagedResponse<PublicationDto> result = service.list(params);
+        Page<PublicationResponse> result = service.findAll(params);
 
-        assertThat(result.content()).isEmpty();
-        assertThat(result.totalElements()).isZero();
-        assertThat(result.page()).isEqualTo(params.getPage());
-        assertThat(result.size()).isEqualTo(params.getSize());
+        assertThat(result.getContent()).containsExactly(first, second);
+        assertThat(result.getTotalElements()).isEqualTo(12);
         verify(queryRepository).findAll(eq(params));
         verifyNoMoreInteractions(queryRepository);
 
-        log.info("empty paged, {}",result);
+        log.info("paged, {}", result);
+    }
+
+    @Test
+    void findAll_shouldReturnEmptyPageWhenRepositoryReturnsEmpty() {
+        PublicationParams params = new PublicationParams();
+        Page<PublicationResponse> emptyPage = new PageImpl<>(List.of(), PageRequest.of(0, 10), 0);
+
+        when(queryRepository.findAll(any(PublicationParams.class))).thenReturn(emptyPage);
+
+        Page<PublicationResponse> result = service.findAll(params);
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+        verify(queryRepository).findAll(eq(params));
+        verifyNoMoreInteractions(queryRepository);
+
+        log.info("empty paged, {}", result);
     }
 
     @Test
     void findById_shouldReturnPublicationWhenExists() {
         Long id = 10L;
-        PublicationDto expected = publicationDto("pub-10", null);
+        PublicationResponse expected = publicationResponse("pub-10");
 
         when(queryRepository.findById(any(Long.class))).thenReturn(Optional.of(expected));
 
-        PublicationDto result = service.findById(id);
+        PublicationResponse result = service.findById(id);
 
         assertThat(result).isEqualTo(expected);
         verify(queryRepository).findById(eq(id));
@@ -98,8 +107,8 @@ class PublicationQueryServiceTest {
         verifyNoMoreInteractions(queryRepository);
     }
 
-    private static PublicationDto publicationDto(String id, Integer totalCount) {
-        return new PublicationDto(
+    private static PublicationResponse publicationResponse(String id) {
+        return new PublicationResponse(
                 id,
                 "title",
                 "description",
@@ -107,14 +116,12 @@ class PublicationQueryServiceTest {
                 "PUBLISHED",
                 null,
                 "file.pdf",
-                "/tmp/file.pdf",
                 123,
                 "Creator",
                 "Manager",
                 1,
                 null,
-                null,
-                totalCount
+                null
         );
     }
 }


### PR DESCRIPTION
## Summary
This PR finalizes the refactoring of the Publication module to align with modern API standards and improve security.

### Key Changes
- **DTO Migration**: Replaced `PublicationDto` with `PublicationResponse` to remove internal file paths from API responses.
- **Secure Download**: Implemented a new secure file download endpoint (`GET /api/publications/{id}/download`) that serves files as `APPLICATION_OCTET_STREAM`.
- **Service Layer Updates**:
  - `PublicationQueryService`: Added `findAll`, `findById`, and `download` methods.
  - `PublicationCommandService`: Updated to reflect DTO and model changes.
- **Test Coverage**: Updated unit tests for both repository and service layers to ensure correctness and prevent regressions.

### Files Modified
- `PublicationController.java`
- `PublicationQueryService.java`
- `PublicationCommandService.java`
- `AttachmentService.java`
- `PublicationResponse.java` (New)
- `PublicationDownloadResult.java` (New)
- `PublicationQueryRepositoryTest.java` (Updated)
- `PublicationQueryServiceTest.java` (Updated)

Verified with `./gradlew compileJava` and unit tests.