### PR TITLE
feat: add docker builder and configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,5 @@ build/
 compose.yml
 docker-compose.yml
 .git/
+*.md
+docker/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .gradle/
-build/
 .idea/
 *.iml
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ application-dev.yml
 inspect/
 /.ollamassist/
 /dummy_prompt.txt
+issue.md

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+IMAGE_NAME := smartoffice-mail
+IMAGE_TAG  := latest
+
+.PHONY: jar image build run clean
+
+## Build JAR inside Docker (no local JDK needed)
+jar:
+	docker compose -f docker/compose.yml build builder
+	UID=$$(id -u) GID=$$(id -g) docker compose -f docker/compose.yml run --rm builder
+
+## Build runtime image (requires JAR in build/libs/)
+image:
+	docker build -t $(IMAGE_NAME):$(IMAGE_TAG) -f docker/Dockerfile .
+
+## Build JAR + image
+build: jar image
+
+## Start full stack (app + db + redis)
+run:
+	docker compose -f docker/compose.yml up -d mail-be mariadb redis
+
+## Stop and clean up
+clean:
+	docker compose -f docker/compose.yml down -v
+	rm -rf build/libs/*.jar

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,14 @@
+FROM eclipse-temurin:25-jre-alpine
+WORKDIR /app
+
+RUN addgroup -S appuser && adduser -S appuser -G appuser -h /app -s /sbin/nologin && \
+    mkdir -p /data/attachments && \
+    chown -R appuser:appuser /app /data/attachments
+
+COPY build/libs/mail-service.jar app.jar
+RUN chown appuser:appuser app.jar
+
+USER appuser
+EXPOSE 8081
+
+ENTRYPOINT ["java", "--enable-native-access=ALL-UNNAMED", "-jar", "app.jar"]

--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -1,0 +1,10 @@
+FROM eclipse-temurin:25-jdk-alpine
+
+# Set up gradle home so dependencies get cached, making it writable for any host user
+ENV GRADLE_USER_HOME=/home/gradle/.gradle
+RUN mkdir -p /home/gradle/.gradle && chmod -R 777 /home/gradle
+
+WORKDIR /app
+
+# The build happens when the container runs, so it respects the mounted volumes and host user
+CMD ["sh", "-c", "chmod +x ./gradlew && ./gradlew clean build -x test"]

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,0 +1,18 @@
+services:
+  # ── Builder (JAR only) ─────────────────────────
+  builder:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.builder
+    image: smartoffice-mail-builder:latest
+    container_name: mail-builder
+    # Run container as host user to ensure build outputs are not owned by root
+    user: "${UID:-1000}:${GID:-1000}"
+    volumes:
+      # Mount full project to run build on source
+      - ..:/app
+      # Cache downloaded dependencies
+      - builder-gradle-cache:/home/gradle/.gradle
+
+volumes:
+  builder-gradle-cache:


### PR DESCRIPTION
This PR adds Docker configuration for building and running the mail-service module. It includes a multi-stage Dockerfile setup for gradle build and running the app in a lightweight alpine JRE container, and a docker-compose.yml for easy configuration.